### PR TITLE
Fixed logic error in function FindMvdInVoteData which always returns …

### DIFF
--- a/mod/scripts/vscripts/takyon_switch.nut
+++ b/mod/scripts/vscripts/takyon_switch.nut
@@ -24,9 +24,9 @@ void function SwitchInit(){
 /*
  *  COMMAND LOGIC
  */
- 
+
 bool function CommandSwitch(entity player, array<string> args){
-    if(!IsLobby()){
+    if(!IsLobby() && !IsFFAGame()){
         printl("USER USED SWITCH")
 
         // check if enabled

--- a/mod/scripts/vscripts/takyon_votebalance.nut
+++ b/mod/scripts/vscripts/takyon_votebalance.nut
@@ -1,7 +1,6 @@
 global function BalanceInit
 global function CommandBalance
 global function BalanceMapEnd
-global function Balance
 
 bool balanceEnabled = true
 bool balanceAtMapEnd = false

--- a/mod/scripts/vscripts/takyon_votebalance.nut
+++ b/mod/scripts/vscripts/takyon_votebalance.nut
@@ -1,6 +1,7 @@
 global function BalanceInit
 global function CommandBalance
 global function BalanceMapEnd
+global function Balance
 
 bool balanceEnabled = true
 bool balanceAtMapEnd = false
@@ -29,7 +30,7 @@ void function BalanceInit(){
  */
 
 bool function CommandBalance(entity player, array<string> args){
-    if(!IsLobby()){
+    if(!IsLobby() && !IsFFAGame()){
         printl("USER USED BALANCE")
         if(!balanceEnabled){
             SendHudMessageBuilder(player, COMMAND_DISABLED, 255, 200, 200)

--- a/mod/scripts/vscripts/takyon_votemap.nut
+++ b/mod/scripts/vscripts/takyon_votemap.nut
@@ -1,5 +1,5 @@
 global function VoteMapInit
-global function FillProposedMaps 
+global function FillProposedMaps
 global function CommandVote
 global function OnPlayerSpawnedMap
 global function OnPlayerDisconnectedMap
@@ -213,7 +213,7 @@ void function ShowProposedMaps(entity player){
     string message = MAP_VOTE_USAGE + "\n"
     for (int i = 1; i <= proposedMaps.len(); i++) {
         string map = TryGetNormalizedMapName(proposedMaps[i-1])
-        message += i + ": " + map + "\n" 
+        message += i + ": " + map + "\n"
     }
 
     // message player
@@ -243,7 +243,7 @@ void function FillProposedMaps(){
     foreach(entity player in GetPlayerArray()){
         ShowProposedMaps(player)
     }
-    
+
     mapsProposalTimeLeft = Time()
     mapsHaveBeenProposed = true
 }
@@ -277,11 +277,10 @@ void function SetNextMap(int num, bool force = false){
 int function FindMvdInVoteData(string mapName){ // returns -1 if not found
     int index = -1
     foreach(MapVotesData mvd in voteData){
-        if(mvd.mapName == mapName)
-            return index
         index++
+        if(mvd.mapName == mapName) return index
     }
-    return index
+    return -1
 }
 
 int function MapVotesSort(MapVotesData data1, MapVotesData data2)


### PR DESCRIPTION
…wrong index

Originally, even if there was no match in the foreach loop, index would always be incremented to 0 and returned.

When the first vote is cast, index is returned correctly as -1
When the next vote is cast and the map name does not match, it returns index of 0 which is the index of the first map that was voted for. Hence why the first cast vote would win.

With these changes, if no match is found in the foreach loop, a hardcoded -1 value is returned and a new value appended to array voteData. If there is a match, then the appropriate index is returned.